### PR TITLE
Add license file for DND Portal

### DIFF
--- a/LISCENSE
+++ b/LISCENSE
@@ -1,0 +1,59 @@
+Copyright © 2025–2026 DND Portal contributors
+All rights reserved.
+
+This software, source code, documentation, designs, interfaces, project
+structure and associated materials are proprietary and protected by
+copyright law.
+
+The source code is made publicly visible for portfolio, educational,
+review and reference purposes only.
+
+No permission is granted to copy, reproduce, modify, distribute,
+redistribute, publish, sublicense, sell, host, deploy, create derivative
+works from, or otherwise reuse this software or substantial portions of
+it without prior written permission from the copyright holders.
+
+You may not deploy or operate a copy of DND Portal, whether modified or
+unmodified, without explicit written permission.
+
+You may not use this repository, or substantial portions of its source
+code, to create or operate a competing, derivative or substantially
+similar application, service or platform.
+
+USER DATA AND PLATFORM DATA
+
+This license applies to the software contained in this repository.
+
+It grants no rights to user-generated content, account information,
+campaign data, character data, uploaded content, private information,
+database contents or any other data stored or processed by the DND
+Portal platform.
+
+Such data is separate from the source code and may be subject to
+additional privacy, contractual and intellectual-property rights.
+
+THIRD-PARTY MATERIAL
+
+Dungeons & Dragons and related names, trademarks, game rules, artwork
+and other intellectual property are the property of their respective
+rights holders.
+
+This license applies only to original DND Portal software, designs and
+materials for which the DND Portal contributors hold the necessary
+rights.
+
+Third-party libraries and dependencies remain subject to their own
+respective licenses.
+
+NO WARRANTY
+
+THE SOFTWARE AND ASSOCIATED MATERIALS ARE PROVIDED "AS IS", WITHOUT
+WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OF THE SOFTWARE.
+
+For permission requests, contact the project maintainers.


### PR DESCRIPTION
Added a license file outlining copyright and usage terms for the DND Portal software.

## Summary

- 

## Type of Change

- [ ] Content update
- [ ] UI or styling change
- [ ] Component or data architecture change
- [ ] Search, routing, or SEO change
- [ ] Build, dependency, or deployment change
- [ ] Documentation only

## Checks

- [ ] `pnpm check`
- [ ] `pnpm build`
- [ ] `pnpm audit:prelive:crawl`

## Screenshots

Add screenshots for visible UI changes.

## Content Sources

List source material, campaign rulings, or project notes used for content changes.

## Deployment Notes

Confirm whether this keeps the static GitHub Pages setup unchanged:

- [ ] Keeps `@sveltejs/adapter-static`
- [ ] Keeps `prerender = true`
- [ ] Keeps `trailingSlash = 'always'`
- [ ] Does not add a repository base path
- [ ] Keeps GitHub Pages artifact deployment

## Legal

- [ ] This PR does not add unauthorized protected publications, paid content, or third-party assets.
- [ ] This PR does not add or change repository licensing terms.
