### PR TITLE
diagnostic: disable Svelte client hydration

### DIFF
--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,2 +1,3 @@
 export const prerender = true;
 export const trailingSlash = 'always';
+export const csr = false;


### PR DESCRIPTION
Temporarily disable SvelteKit client-side rendering and hydration (`csr = false`) to isolate a production issue where one specific phone loses all global styling shortly after JavaScript starts running, while the same site works correctly on another phone with the same model and browser versions. With JavaScript disabled, the affected phone keeps the prerendered HTML and CSS styling, confirming that the initial static output is correct. A previous JSON-LD diagnostic did not resolve the issue. This merge keeps prerendered HTML, CSS, and Google Analytics intact while removing the SvelteKit client hydration/runtime, allowing us to confirm whether hydration is the component causing the stylesheet to disappear. This is a temporary diagnostic change and not intended as a permanent fix.