### PR TITLE
diagnostic: trace stylesheet removal during hydration

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -5,6 +5,88 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<meta name="text-scale" content="scale" />
 
+		<script>
+			(() => {
+				const storageKey = 'dnd-hydration-debug';
+				const maxRecords = 30;
+				const debug = (window.__dndHydrationDebug = window.__dndHydrationDebug || []);
+				const recentErrors = [];
+
+				const save = () => {
+					try { localStorage.setItem(storageKey, JSON.stringify(debug.slice(-maxRecords))); } catch {}
+				};
+				const record = (record) => {
+					debug.push(record);
+					if (debug.length > maxRecords) debug.splice(0, debug.length - maxRecords);
+					save();
+					if (record.type === 'stylesheet-removal') showOverlay();
+				};
+				const stylesheet = (node) => {
+					if (!(node instanceof Element)) return null;
+					if (node.matches('link[rel="stylesheet"]')) return node;
+					return node.querySelector('link[rel="stylesheet"]');
+				};
+				const removed = (operation, node) => {
+					const link = stylesheet(node);
+					if (!link) return;
+					record({
+						type: 'stylesheet-removal',
+						timestamp: new Date().toISOString(),
+						operation,
+						removedNode: node.outerHTML || String(node),
+						href: link.href || link.getAttribute('href') || '',
+						stack: new Error().stack || '',
+						location: document.location.href
+					});
+				};
+				const wrap = (prototype, method) => {
+					const original = prototype[method];
+					prototype[method] = function (...args) {
+						if (method === 'replaceChildren') args.forEach((node) => removed('replaceChildren', node));
+						else removed(method, method === 'removeChild' || method === 'replaceChild' ? args[method === 'removeChild' ? 0 : 1] : this);
+						return original.apply(this, args);
+					};
+				};
+				wrap(Node.prototype, 'removeChild');
+				wrap(Node.prototype, 'replaceChild');
+				wrap(Element.prototype, 'remove');
+				wrap(Element.prototype, 'replaceWith');
+				wrap(Element.prototype, 'replaceChildren');
+				new MutationObserver((mutations) => mutations.forEach((mutation) => mutation.removedNodes.forEach((node) => removed('MutationObserver', node)))
+				).observe(document.head, { childList: true, subtree: true });
+				const runtimeError = (type, detail) => {
+					const entry = { type, timestamp: new Date().toISOString(), detail, location: document.location.href };
+					recentErrors.push(entry);
+					if (recentErrors.length > 10) recentErrors.shift();
+					debug.push(entry);
+					if (debug.length > maxRecords) debug.splice(0, debug.length - maxRecords);
+					save();
+				};
+				window.addEventListener('error', (event) => runtimeError('error', event.error?.stack || event.message || String(event.error)));
+				window.addEventListener('unhandledrejection', (event) => runtimeError('unhandledrejection', event.reason?.stack || String(event.reason)));
+				const report = () => debug.slice(-maxRecords).map((entry) => JSON.stringify(entry, null, 2)).join('\n\n');
+				function showOverlay() {
+					if (document.getElementById('dnd-hydration-debug-overlay')) return;
+					const overlay = document.createElement('div');
+					overlay.id = 'dnd-hydration-debug-overlay';
+					overlay.style.cssText = 'position:fixed;z-index:2147483647;inset:8px;background:#fff;color:#111;border:3px solid #b00;padding:12px;overflow:auto;font:14px/1.4 monospace;box-sizing:border-box;';
+					const title = document.createElement('h2'); title.textContent = 'D&D Hydration Debug'; title.style.cssText = 'font:700 20px sans-serif;margin:0 0 10px;'; overlay.append(title);
+					const latest = debug.filter((entry) => entry.type === 'stylesheet-removal').slice(-1)[0];
+					const details = document.createElement('pre'); details.textContent = latest ? `Operation: ${latest.operation}\nStylesheet: ${latest.href}\n\nStack:\n${latest.stack}\n\nErrors:\n${recentErrors.map((entry) => `${entry.type}: ${entry.detail}`).join('\n') || 'None'}` : report(); details.style.cssText = 'white-space:pre-wrap;overflow-wrap:anywhere;'; overlay.append(details);
+					const copy = document.createElement('button'); copy.textContent = 'Copy debug'; copy.style.cssText = 'padding:8px;margin:8px 8px 8px 0;'; copy.onclick = () => { const fallback = () => { const area = document.createElement('textarea'); area.value = report(); area.style.cssText = 'display:block;width:100%;height:180px;'; overlay.append(area); area.select(); }; if (navigator.clipboard) navigator.clipboard.writeText(report()).catch(fallback); else fallback(); }; overlay.append(copy);
+					const close = document.createElement('button'); close.textContent = 'Close'; close.style.cssText = 'padding:8px;'; close.onclick = () => overlay.remove(); overlay.append(close);
+					document.body.append(overlay);
+				}
+				try {
+					const stored = JSON.parse(localStorage.getItem(storageKey) || '[]');
+					if (Array.isArray(stored)) stored.slice(-maxRecords).forEach((entry) => debug.push(entry));
+				} catch {}
+				if (new URLSearchParams(document.location.search).get('hydration-debug') === '1' && debug.length) {
+					if (document.body) showOverlay(); else addEventListener('DOMContentLoaded', showOverlay, { once: true });
+				}
+			})();
+		</script>
+
 		<!-- Google Analytics -->
 		<script async src="https://www.googletagmanager.com/gtag/js?id=G-6X1M5VW1SF"></script>
 		<script>

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,3 +1,2 @@
 export const prerender = true;
 export const trailingSlash = 'always';
-export const csr = false;


### PR DESCRIPTION
Temporarily restore SvelteKit client-side rendering and hydration and add early runtime instrumentation to trace the production issue where the global stylesheet disappears after hydration on one specific device.

Previous diagnostics confirmed that the prerendered HTML and CSS are correct and that the issue disappears when SvelteKit client hydration is disabled with `csr = false`. This branch therefore re-enables hydration and adds a lightweight diagnostic script in `src/app.html` that monitors stylesheet-removal DOM operations, head mutations, runtime errors, and unhandled promise rejections.

When the stylesheet is removed, the diagnostic captures the operation, stylesheet URL, timestamp, page URL, and JavaScript stack trace, then displays the result in an inline-styled overlay that remains readable even after the global CSS disappears. Diagnostic data is also stored locally so it can be reopened with `?hydration-debug=1`.

This merge is strictly for debugging and does not attempt to fix the underlying hydration issue.