### PR TITLE
fix(seo): stabilize head hydration structure

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -69,12 +69,14 @@
 	<meta property="og:url" content={seo.canonicalUrl} />
 	<meta property="og:image" content={seo.imageUrl} />
 	<meta property="og:image:alt" content={seo.imageAlt} />
-	{#if seo.imageWidth}
-		<meta property="og:image:width" content={String(seo.imageWidth)} />
-	{/if}
-	{#if seo.imageHeight}
-		<meta property="og:image:height" content={String(seo.imageHeight)} />
-	{/if}
+	<meta
+		property="og:image:width"
+		content={seo.imageWidth == null ? undefined : String(seo.imageWidth)}
+	/>
+	<meta
+		property="og:image:height"
+		content={seo.imageHeight == null ? undefined : String(seo.imageHeight)}
+	/>
 	<meta name="twitter:card" content={seo.twitterCard} />
 	<meta name="twitter:title" content={seo.title} />
 	<meta name="twitter:description" content={seo.description} />


### PR DESCRIPTION
Stabilize the root SEO head structure to prevent Svelte hydration mismatch recovery from removing the global stylesheet on the affected device.

Runtime diagnostics traced the stylesheet removal to Svelte's hydration mismatch recovery for the conditional `seo.imageWidth` / `seo.imageHeight` blocks inside `<svelte:head>`. The mismatch caused Svelte to call `skip_nodes()`, which removed the generated global `<link rel="stylesheet">`.

This change removes those structural `{#if}` blocks and keeps the Open Graph width/height meta elements permanently present, allowing only their `content` attributes to change. CSR and client hydration remain fully enabled.

The existing runtime instrumentation is intentionally retained for this deployment so we can verify that the stylesheet is no longer removed.

This is the targeted fix for the hydration issue; unrelated code and the class redesign are unchanged.